### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server for Chrome browser automation via debugging protocol, specifically designed to connect to Chrome debugging ports and enable browser automation with persistent login sessions.
 
+<a href="https://glama.ai/mcp/servers/@Rainmen-xia/chrome-debug-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Rainmen-xia/chrome-debug-mcp/badge" alt="Chrome Debug Server MCP server" />
+</a>
+
 ## 🎯 Project Advantages
 
 ### 🚀 Core Technical Advantages
@@ -364,4 +368,4 @@ MIT License
 
 ---
 
-**Core Advantage**: The biggest feature of this MCP server is its ability to connect to existing Chrome instances and maintain login sessions, making it ideal for automation scenarios requiring user authentication. Through Chrome debug ports, it can take over user-logged browser sessions, achieving true "session-persistent" browser automation. 
+**Core Advantage**: The biggest feature of this MCP server is its ability to connect to existing Chrome instances and maintain login sessions, making it ideal for automation scenarios requiring user authentication. Through Chrome debug ports, it can take over user-logged browser sessions, achieving true "session-persistent" browser automation.


### PR DESCRIPTION
This PR adds a badge for the [Chrome Debug MCP Server](https://glama.ai/mcp/servers/@Rainmen-xia/chrome-debug-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Rainmen-xia/chrome-debug-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Rainmen-xia/chrome-debug-mcp/badge" alt="Chrome Debug Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.